### PR TITLE
Add pre-commit hook for trailing newline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+  - repo: local
+    hooks:
+      - id: check-final-newline
+        name: Check for trailing newline
+        entry: scripts/check-final-newline.sh
+        language: script
+        pass_filenames: true

--- a/scripts/check-final-newline.sh
+++ b/scripts/check-final-newline.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Fail if any specified file lacks a trailing newline.
+
+ret=0
+for f in "$@"; do
+    [ -f "$f" ] || continue
+    # skip binary files
+    if grep -Iq . "$f" 2>/dev/null; then
+        # get ASCII code of last byte
+        last_byte=$(tail -c1 "$f" | od -An -t u1 | tr -d ' \n')
+        if [ -n "$last_byte" ] && [ "$last_byte" != "10" ]; then
+            echo "$f: missing trailing newline"
+            ret=1
+        fi
+    fi
+done
+exit $ret


### PR DESCRIPTION
## Summary
- add a `.pre-commit-config.yaml` with a trailing newline checker
- create `check-final-newline.sh` to fail when files lack a final newline

## Testing
- `pre-commit run --files .pre-commit-config.yaml scripts/check-final-newline.sh`

------
https://chatgpt.com/codex/tasks/task_e_6841b28df3388328aead3ab0735d9489