### PR TITLE
Add docs generation steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ checkpoints/final_model.pt
 benchmark_results_*/
 *.png
 !README_images/*.png  # Keep any images needed for the README
+edgeformer-docs/site/

--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ python showcase_edgeformer.py
 """
 ```
 
+### **Generating Documentation**
+```bash
+python scripts/generate_docs.py --output_dir edgeformer-docs/docs
+mkdocs build -f edgeformer-docs/mkdocs.yml
+```
+*The generated site in `edgeformer-docs/site/` is ignored by Git.*
+
 ---
 
 ## 🏗️ **Production-Ready Architecture**


### PR DESCRIPTION
## Summary
- explain how to build the docs using `generate_docs.py` and `mkdocs`
- note that the generated `site/` folder is git-ignored
- ignore the documentation output folder in `.gitignore`

## Testing
- `python run_tests.py --component model --test-pattern 'test_*.py'` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6841b6e2e7d0832883f6315ac160ac44